### PR TITLE
Fix calibration when GPU is not used

### DIFF
--- a/modules/SFM/SFM.cpp
+++ b/modules/SFM/SFM.cpp
@@ -335,6 +335,7 @@ bool SFM::updateModule()
         mutexDisp.lock();
         this->stereo->setMatches(leftM,rightM);
 #else
+        mutexDisp.lock();
         this->stereo->findMatch(false);
 #endif
         this->stereo->estimateEssential();


### PR DESCRIPTION
Hi @pattacini,
I think this patch solves a bug that SFM is crashing when recalibrating.

Best,
Tobi